### PR TITLE
Added link to VIVO development process wiki page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+**Thank you for submitting a pull request! Please title this pull request with a brief description of what it fixes, improves or changes. In the template below, please provide a detailed description of the pull request.**
+
+**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: (please link to issue)
+
+* Other relevant links (mailing list discussion, related pull requests, etc.)
+
+# What does this pull request do?
+A detailed description of the changes made by this PR. Technical details and potential side effects. Include screenshots, diagrams or examples where appropriate.
+
+# What's new?
+A detailed description of the changes made by this PR. Technical details and potential side effects. Include screenshots, diagrams or examples where appropriate.
+
+Example:
+* Changes class x to such that y
+* Added x
+* Removed y
+
+# Additional notes:
+Any additional information that you think would be helpful in reviewing this PR.
+
+Example:
+* Does this change require documentation to be updated? 
+* Does this change add any new dependencies or ontology imports? 
+* Does this change require any other changes to be made to the repository? 
+* Could this change affect the VIVO application or data described with the ontology?
+* Large pull requests should be avoided. If this PR is large, please provide a brief explanation as to why your contribution can't be split in smaller PRs. 
+
+# Interested parties
+Tag (@ mention) interested parties or.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ The VIVO Ontology is used to represent scholarship.
 
 ## A note about licensing
 
-The VIVO Ontology is in the public domain, and free to use.  The VIVO Ontology file includes terms from other ontologies.  These ontologies
-may have their own licenses and may not be in the public domain.  While the VIVO Project has made every effort to ascertain the
-licenses of each of the terms it uses, this has not always been possible.  Some of these terms may have licenses that prevent
+The VIVO Ontology is in the public domain, and free to use. The VIVO Ontology file includes terms from other ontologies. These ontologies
+may have their own licenses and may not be in the public domain. While the VIVO Project has made every effort to ascertain the
+licenses of each of the terms it uses, this has not always been possible. Some of these terms may have licenses that prevent
 their use in some settings.
 
 ## A note about development
 
 The VIVO Ontology and related *VIVO ontologies* are under active development by the [VIVO Ontology Interest Group](https://wiki.lyrasis.org/display/VIVO/Ontology+Interest+Group) of the [VIVO Project](https://vivoweb.org).
-The group holds regular meetings and is open to all.  Please consider participating.
+The group holds regular meetings and is open to all. Please consider participating.
 
-VIVO Ontologies is an open source open community.  All are welcome to open issues, participate in discussions, and generate pull reqeuests.
+VIVO Ontologies is an open source community.  All are welcome to open issues, participate in discussions, and generate pull reqeuests.
+
+You can contribute using the fork, branch and pull model. Helpful descriptions of the process are available [on the VIVO wiki](https://wiki.lyrasis.org/display/VIVO/Contributing+code+with+a+fork%2C+branches%2C+and+pull+requests).

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ their use in some settings.
 The VIVO Ontology and related *VIVO ontologies* are under active development by the [VIVO Ontology Interest Group](https://wiki.lyrasis.org/display/VIVO/Ontology+Interest+Group) of the [VIVO Project](https://vivoweb.org).
 The group holds regular meetings and is open to all. Please consider participating.
 
-VIVO Ontologies is an open source community.  All are welcome to open issues, participate in discussions, and generate pull reqeuests.
+VIVO Ontologies is an open source community. All are welcome to open issues, participate in discussions, and generate pull reqeuests.
 
 You can contribute using the fork, branch and pull model. Helpful descriptions of the process are available [on the VIVO wiki](https://wiki.lyrasis.org/display/VIVO/Contributing+code+with+a+fork%2C+branches%2C+and+pull+requests).


### PR DESCRIPTION
Addresses https://github.com/vivo-ontologies/vivo-ontology/issues/8. 

Additionally removes some duplicate spaces. 