### PR TITLE
Removed domain statement from bibo:doi

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -4104,7 +4104,6 @@ Definition and description came from Wikipedia here: http://en.wikipedia.org/wik
         <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://purl.org/ontology/bibo/</rdfs:isDefinedBy>
         <ns:term_status>stable</ns:term_status>
         <rdfs:comment xml:lang="en">Digital Object Identifier</rdfs:comment>
-        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <rdfs:subPropertyOf rdf:resource="http://purl.org/ontology/bibo/identifier"/>
     </owl:DatatypeProperty>
 


### PR DESCRIPTION
Removed domain statement from bibo:doi

**Thank you for submitting a pull request! Please title this pull request with a brief description of what it fixes, improves or changes. In the template below, please provide a detailed description of the pull request.**

**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: https://github.com/vivo-ontologies/vivo-ontology/issues/17

* Other relevant links (mailing list discussion, related pull requests, etc.)
* (https://wiki.lyrasis.org/display/VIVO/2024-05-22+Ontology+Interest+Group+Call)


# What does this pull request do?
Removes the domain class from bibo:doi.


Example:
* Requires documentation to be updated 
* Could this change affect the VIVO application or data described with the ontology? A restriction for the property bibo:doi is need to be able to add DOIs manually.
* Large pull requests should be avoided. If this PR is large, please provide a brief explanation as to why your contribution can't be split in smaller PRs. 

# Interested parties
Tag (@ mention) interested parties or.
