### PR TITLE
Readme release information

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,18 @@ VIVO Ontologies is an open source community. All are welcome to open issues, par
 You can contribute using the fork, branch and pull model. Helpful descriptions of the process are available [on the VIVO wiki](https://wiki.lyrasis.org/display/VIVO/Contributing+code+with+a+fork%2C+branches%2C+and+pull+requests).
 
 ## Releases
+### Semantic Versioning
+This ontology adheres to the principles of Semantic Versioning (SemVer) for managing its releases. Semantic Versioning provides a standardized approach for versioning ontologies, allowing users to quickly understand the scope of changes between versions.
+
+### Versioning Scheme
+- Major Release: Indicates substantial changes, such as alterations to the ontology's core structure or significant shifts in semantics.
+- Minor Release: Introduces new concepts or properties in a manner consistent with existing ontology structures.
+- Patch Release: Includes bug fixes or minor updates without modifying the ontology's core structure or semantics.
+
 ### Latest ontology file
-The latest version of the ontology can always be found at:
+The latest version of the ontology file can be found at:
 https://raw.githubusercontent.com/vivo-ontologies/vivo-ontology/master/vivo.owl
-### Stable release versions
-Semantic Versioning is being used for publishing releases. They can be found at:
+
+### Release versions
+Release versions be found at:
 https://github.com/vivo-ontologies/vivo-ontology/releases

--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ The group holds regular meetings and is open to all. Please consider participati
 VIVO Ontologies is an open source community. All are welcome to open issues, participate in discussions, and generate pull reqeuests.
 
 You can contribute using the fork, branch and pull model. Helpful descriptions of the process are available [on the VIVO wiki](https://wiki.lyrasis.org/display/VIVO/Contributing+code+with+a+fork%2C+branches%2C+and+pull+requests).
+
+## Releases
+### Latest ontology file
+The latest version of the ontology can always be found at:
+https://raw.githubusercontent.com/vivo-ontologies/vivo-ontology/master/vivo.owl
+### Stable release versions
+Semantic Versioning is being used for publishing releases. They can be found at:
+https://github.com/vivo-ontologies/vivo-ontology/releases


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: 
https://github.com/vivo-ontologies/vivo-ontology/issues/4

* Other relevant links (mailing list discussion, related pull requests, etc.)
https://wiki.lyrasis.org/display/VIVO/2023-12-06+Ontology+Interest+Group+Call

# What does this pull request do?
Adds information about releases and semantic versioning to the Readme

# What's new?
see above

# Additional notes:
Reviewer: Please check if this is consistant with our decisions in the Ontology Calls.

# Interested parties
@brianjlowe @tawahle @melanieWacker 
