### PR TITLE
Set .gitattributes to eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior for end of line to lf
+* text=auto eol=lf


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: Closes https://github.com/vivo-ontologies/vivo-ontology/issues/19

* Other relevant links (mailing list discussion, related pull requests, etc.)
-

# What does this pull request do?
Adds .gitattributes to enforce consistent use of line endings (* text=auto eol=lf)

# What's new?
Consistent line endings, independent of who contributes and how.

# Additional notes:
Any additional information that you think would be helpful in reviewing this PR.

* Does this change require documentation to be updated? 
No

# Interested parties
@chenejac @brianjlowe 
