### PR TITLE
Changing domain of relates property for Authorship to include Software

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -8786,7 +8786,7 @@ has super-classes</obo:IAO_0000115>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://vivoweb.org/ontology/core#relates"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
+                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000002"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string"></rdfs:comment>


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: [44](https://github.com/vivo-ontologies/vivo-ontology/issues/44)

# What does this pull request do?
Domain for relates property into Authorship has been changed to  http://purl.obolibrary.org/obo/BFO_0000002


# Interested parties
Tag (@ mention) interested parties or.
