### PR TITLE
Download, code repository and license URLs as Software data properties

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -6397,7 +6397,23 @@ To enable other Gender/Sex codes to be used, this dataproperty has range URI. Th
         <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
     </owl:Class>
 
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#downloadURL">
+        <rdfs:label xml:lang="en">download URL</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/ERO_0000071"/>
+    </owl:DatatypeProperty>
 
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#codeRepositoryURL">
+        <rdfs:label xml:lang="en">code repository URL</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/ERO_0000071"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#licenseURL">
+        <rdfs:label xml:lang="en">license URL</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/ERO_0000071"/>
+    </owl:DatatypeProperty>
 
     <!-- http://purl.obolibrary.org/obo/ERO_0000224 -->
 


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: [40](https://github.com/vivo-ontologies/vivo-ontology/issues/40)

# What does this pull request do?
Adds download, code repository and license URLs as data properties, domain is Software, range is URI. 

# Additional notes:
This is an alternative for [41](https://github.com/vivo-ontologies/vivo-ontology/pull/41), only one of those two PRs should be merged. This is more simple one, linked only with Software, and in the case the ontology is updated in the VIVO platform no code improvements/alignments needed. 

# Interested parties
Tag (@ mention) interested parties or.
