### PR TITLE
Add ROR ID

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -4772,6 +4772,16 @@ Definition source: http://isiwebofknowledge.com/researcherid/</obo:IAO_0000112>
     </owl:DatatypeProperty>
 
 
+    <!-- http://vivoweb.org/ontology/core#rorId -->
+
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#rorId">
+        <rdfs:label xml:lang="en">ROR ID</rdfs:label>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The ROR ID is a unique identifier for organizations in the Research Organization Registry (ROR), which is a global, community-led registry of open persistent identifiers for research organizations.
+Definition source: https://ror.org/about/</obo:IAO_0000112>
+        <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
+        <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
+    </owl:DatatypeProperty>
+
 
     <!-- http://vivoweb.org/ontology/core#scopusId -->
 


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: https://github.com/vivo-ontologies/vivo-ontology/issues/55

* https://ror.org

# What does this pull request do?
This PR adds a data property for the Research Organization Registry ID (ROR) to the VIVO Ontology.

# What's new?
- http://vivoweb.org/ontology/core#rorId as a data property
- subproperty of vivo:identifier
- domain is foaf:Organization

# Additional notes:
* Requires change of the documentation 
* Add no new dependencies or ontology imports
* Could this change affect the VIVO application or data described with the ontology?
  *  It might be useful to think about adding ROR IDs to certain custom entry forms, but it is not strictly required for VIVO to function

# Interested parties
@vivo-ontologies/team-members 