### PR TITLE
Added dc:description for the VIVO Ontology

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <rdf:RDF xmlns="http://vivoweb.org/ontology/core#"
      xml:base="http://vivoweb.org/ontology/core"
      xmlns:study_protocol="http://purl.org/net/OCRe/study_protocol.owl#"

--- a/vivo.owl
+++ b/vivo.owl
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <rdf:RDF xmlns="http://vivoweb.org/ontology/core#"
      xml:base="http://vivoweb.org/ontology/core"
      xmlns:study_protocol="http://purl.org/net/OCRe/study_protocol.owl#"
@@ -14,11 +13,13 @@
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
+	 xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:statistics="http://purl.org/net/OCRe/statistics.owl#">
 
     <owl:Ontology rdf:about="http://vivoweb.org/ontology/core">
         <rdfs:label xml:lang="en-US">VIVO Core Ontology</rdfs:label>
         <terms:license rdf:resource="https://spdx.org/licenses/Unlicense.html"/>
+        <dc:description xml:lang="en">The VIVO Ontology is used to represent the expertise of people engaged in the creation, transmission, and preservation of knowledge and creative works. The VIVO ontology (hereafter referred to as “the ontology”) represents expertise by describing the activities and accomplishments of people in terms of their relationships to particular artifacts of the work, resources they use, institutions that employ them, and other indicators. The ontology is independent of knowledge or creative domain. The ontology supports the identification, evaluation, and impact assessment of individual people and groups of people, as well as identification and reuse of the works of the people.</dc:description>
     </owl:Ontology>
 
     <!--

--- a/vivo.owl
+++ b/vivo.owl
@@ -13,13 +13,12 @@
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
-	 xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:statistics="http://purl.org/net/OCRe/statistics.owl#">
 
     <owl:Ontology rdf:about="http://vivoweb.org/ontology/core">
         <rdfs:label xml:lang="en-US">VIVO Core Ontology</rdfs:label>
         <terms:license rdf:resource="https://spdx.org/licenses/Unlicense.html"/>
-        <dc:description xml:lang="en">The VIVO Ontology is used to represent the expertise of people engaged in the creation, transmission, and preservation of knowledge and creative works. The VIVO ontology (hereafter referred to as “the ontology”) represents expertise by describing the activities and accomplishments of people in terms of their relationships to particular artifacts of the work, resources they use, institutions that employ them, and other indicators. The ontology is independent of knowledge or creative domain. The ontology supports the identification, evaluation, and impact assessment of individual people and groups of people, as well as identification and reuse of the works of the people.</dc:description>
+        <terms:description xml:lang="en">The VIVO Ontology is used to represent the expertise of people engaged in the creation, transmission, and preservation of knowledge and creative works. The VIVO ontology (hereafter referred to as “the ontology”) represents expertise by describing the activities and accomplishments of people in terms of their relationships to particular artifacts of the work, resources they use, institutions that employ them, and other indicators. The ontology is independent of knowledge or creative domain. The ontology supports the identification, evaluation, and impact assessment of individual people and groups of people, as well as identification and reuse of the works of the people.</dc:description>
     </owl:Ontology>
 
     <!--


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: https://github.com/vivo-ontologies/vivo-ontology/issues/59

# What does this pull request do?
This PR adds information a description of the VIVO Ontology to the vivo.owl. The domain definition was taken from https://github.com/openrif/vivo-isf-ontology/wiki/VIVO-Ontology-Domain-Definition (by @mconlon17).

# What's new?
1. Added namespace for DC elements.
2. Added the description.

# Interested parties
@vivo-ontologies/team-members 
