### PR TITLE
Added doap:repository

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -15,10 +15,12 @@
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:statistics="http://purl.org/net/OCRe/statistics.owl#">
+     xmlns:doap="http://usefulinc.com/ns/doap#">	
 
     <owl:Ontology rdf:about="http://vivoweb.org/ontology/core">
         <rdfs:label xml:lang="en-US">VIVO Core Ontology</rdfs:label>
         <terms:license rdf:resource="https://spdx.org/licenses/Unlicense.html"/>
+	<doap:repository rdf:resource="https://github.com/vivo-ontologies/vivo-ontology"/>
     </owl:Ontology>
 
     <!--


### PR DESCRIPTION
Added doap:repository


**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: ([please link to issue](https://github.com/vivo-ontologies/vivo-ontology/issues/60))

# What does this pull request do?
This PR adds information about the repository, where the VIVO Ontology is stored. 

# What's new?
Added namespace for doap.
Added the statement for the repository information.

# Interested parties
[Tag (@ mention) interested parties or.](https://github.com/orgs/vivo-ontologies/teams/team-members)
