### PR TITLE
Added vann:preferredNamespacePrefix

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -14,12 +14,14 @@
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:vann="http://purl.org/vocab/vann/"
      xmlns:statistics="http://purl.org/net/OCRe/statistics.owl#">
 
     <owl:Ontology rdf:about="http://vivoweb.org/ontology/core">
         <rdfs:label xml:lang="en-US">VIVO Core Ontology</rdfs:label>
         <terms:license rdf:resource="https://spdx.org/licenses/Unlicense.html"/>
         <terms:creator rdf:resource="VIVO Ontology Interest Group"/>
+        <vann:preferredNamespacePrefix>vivo</vann:preferredNamespacePrefix>
     </owl:Ontology>
 
     <!--


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: https://github.com/vivo-ontologies/vivo-ontology/issues/57

# What does this pull request do?
Adds the preferred namespace 'vivo' to the ontology metadata.

# What's new?
Adds vann ontology and:
'<vann:preferredNamespacePrefix>vivo</vann:preferredNamespacePrefix>'

# Interested parties
@vivo-ontologies/team-members @Sarndt-TIB