### PR TITLE
Added doap:bug-database

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -21,7 +21,8 @@
     <owl:Ontology rdf:about="http://vivoweb.org/ontology/core">
         <rdfs:label xml:lang="en-US">VIVO Core Ontology</rdfs:label>
         <terms:license rdf:resource="https://spdx.org/licenses/Unlicense.html"/>
-	      <doap:repository rdf:resource="https://github.com/vivo-ontologies/vivo-ontology"/>
+        <doap:repository rdf:resource="https://github.com/vivo-ontologies/vivo-ontology"/>
+        <doap:bug-database rdf:resource="https://github.com/vivo-ontologies/vivo-ontology/issues"/>
         <terms:creator rdf:resource="VIVO Ontology Interest Group"/>
         <vann:preferredNamespacePrefix>vivo</vann:preferredNamespacePrefix>
     </owl:Ontology>


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: https://github.com/vivo-ontologies/vivo-ontology/issues/61

# Other relevant links (mailing list discussion, related pull requests, etc.)
* https://github.com/vivo-ontologies/vivo-ontology/issues/22

# What does this pull request do?
Adds a linkt to the Github issues in the VIVO Ontology repo to the OWL's metadata.

# What's new?
Fixed indenting on one line, added the following:

`<doap:bug-database rdf:resource="https://github.com/vivo-ontologies/vivo-ontology/issues"/>`

# Interested parties
@vivo-ontologies/team-members 