### PR TITLE
Add Wikidata ID

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -4791,6 +4791,16 @@ Definition source: https://ror.org/about/</obo:IAO_0000112>
     </owl:DatatypeProperty>
 
 
+    <!-- http://vivoweb.org/ontology/core#wikidataiD -->
+
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#wikidataiD">
+        <rdfs:label xml:lang="en">Wikidata ID</rdfs:label>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifier being used by Wikidata to identify entities in Wikidata.org. Entity ID URIs follow the pattern http://www.wikidata.org/entity/ID where ID is an entity ID.</obo:IAO_0000112>
+        <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://www.wikidata.org/wiki/Wikidata:Identifiers</rdfs:isDefinedBy>
+    </owl:DatatypeProperty>
+
+
     <!-- http://vivoweb.org/ontology/core#scopusId -->
 
     <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#scopusId">
@@ -4811,6 +4821,7 @@ Definition source: https://ror.org/about/</obo:IAO_0000112>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition modified from: source (http://en.wikipedia.org/wiki/Seating_capacity).</obo:IAO_0000112>
         <rdfs:domain rdf:resource="http://vivoweb.org/ontology/core#Room"/>
         <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+
     </owl:DatatypeProperty>
 
 


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: 
- https://github.com/vivo-ontologies/vivo-ontology/issues/75
- https://github.com/vivo-ontologies/vivo-ontology/issues/77
- https://github.com/vivo-ontologies/vivo-ontology/issues/78
- https://github.com/vivo-ontologies/vivo-ontology/issues/79
- https://github.com/vivo-ontologies/vivo-ontology/issues/80
- https://github.com/vivo-ontologies/vivo-ontology/issues/81

# What does this pull request do?
Adds Wikidata ID to the VIVO Ontology. The Wikidata ID has no Domain, because it can be used for practically all entities (continuants and occurents). 

# What's new?
The data property vivo:wikidataID was added as a subproperty to vivo:identifier. No range is given so far to be consistent with the current practice. This issue should be dealt with separately, in https://github.com/vivo-ontologies/vivo-ontology/issues/83. 

* Does this change require documentation to be updated?
Not necessarily. On overview about supported IDs would be generally benefial, though.

* Does this change add any new dependencies or ontology imports? 
No.

* Does this change require any other changes to be made to the repository? 
No.

* Could this change affect the VIVO application or data described with the ontology?
It's an additional option to add IDs to entities. It would be good to add it to the property group `identity`.

# Interested parties
@vivo-ontologies/team-members 
