### PR TITLE
Add GND ID

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -4155,6 +4155,17 @@ The Uniform Code Council (UCC) was the Numbering Organization in the USA to admi
 
 
 
+    <!-- http://vivoweb.org/ontology/core#gndID -->
+
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#gndID">
+        <rdfs:label xml:lang="en">GND ID</rdfs:label>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Identifier being used by Common Authority File (GND) of the German National Library (DNB) to represent  entities, i.e. persons, corporate bodies, conferences, locations, concepts and works that are related to cultural and scientific collections.</obo:IAO_0000112>
+        <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
+        <rdfs:isDefinedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://www.dnb.de/DE/Professionell/Standardisierung/GND/gnd_node.html</rdfs:isDefinedBy>
+    </owl:DatatypeProperty>
+
+
+
     <!-- http://purl.org/ontology/bibo/gtin14 -->
 
     <owl:DatatypeProperty rdf:about="http://purl.org/ontology/bibo/gtin14">


### PR DESCRIPTION

**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: 

* [Add IDs for persons #75](https://github.com/vivo-ontologies/vivo-ontology/issues/75)
* [Add IDs for persons #76](https://github.com/vivo-ontologies/vivo-ontology/issues/76)
* [GND-ID als data property #8](https://github.com/VIVO-DE/vivo-de-ontology-extension/issues/8)


# What does this pull request do?
Adds GND ID to the VIVO Ontology. The GND ID has no Domain, because it can be used for several types of entities (continuants and occurents).

# What's new?
The data property vivo:gndID was added as a subproperty to vivo:identifier. No range is given so far to be consistent with the current practice. This issue should be dealt with separately, in https://github.com/vivo-ontologies/vivo-ontology/issues/83.


* Does this change require documentation to be updated? Not necessarily. On overview about supported IDs would be generally benefial, though.
* Does this change add any new dependencies or ontology imports? No, it doesn't require any ontology imports.
* Does this change require any other changes to be made to the repository? No.
* Could this change affect the VIVO application or data described with the ontology? It's an additional option to add IDs to entities. It would be good to add it to the property group _identity_. There is probably a need to add a restriction for this property in the restriction file, so that one can use the property in the application.


# Interested parties
@vivo-ontologies/team-members
