### PR TITLE
Add dblp ID

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -4799,7 +4799,7 @@ Definition source: https://ror.org/about/</obo:IAO_0000112>
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
     </owl:DatatypeProperty>
 
-    <!-- http://vivoweb.org/ontology/core#dblpId -->
+    <!-- http://vivoweb.org/ontology/core#dblpPersonKey -->
 
     <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#dblpPersonKey">
         <rdfs:label xml:lang="en">dblp Person Key</rdfs:label>

--- a/vivo.owl
+++ b/vivo.owl
@@ -4801,11 +4801,21 @@ Definition source: https://ror.org/about/</obo:IAO_0000112>
 
     <!-- http://vivoweb.org/ontology/core#dblpId -->
 
-    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#dblpId">
-        <rdfs:label xml:lang="en">dblp ID</rdfs:label>
-        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The dblp computer science bibliography provides open bibliographic information on major computer science journals and proceedings. Definition source: https://dblp.org/. The DBLP ID uniquely identifies researchers in the DBLP.</obo:IAO_0000112>
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#dblpPersonKey">
+        <rdfs:label xml:lang="en">dblp Person Key</rdfs:label>
         <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
-        <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+        <rdfs:isDefinedBy rdf:resource="http://vivoweb.org/ontology/core"/>
+        <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>     
+        <obo:IAO_0000111 xml:lang="en">dblp Person Key</obo:IAO_0000111>
+        <rdfs:comment xml:lang="en">A dblp person key identifies a person with a unique identifier assigned by dblp. They are alphanumeric strings (e.g., Q28136655) that serve as the local identifiers for persons in the dblp.</rdfs:comment>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A dblp Person Key identifies a unique person in dblp such as https://dblp.org/pid/53/6062.html for Michael Conlon.</obo:IAO_0000112>
+        <vitro:exampleAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://dblp.org/pid/53/6062.html</vitro:exampleAnnot>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">In many ways, persons are identified in dblp on basis of the persons name string (optionally followed by a four digit number in case of several authors in dblp with the same name). That name can be found prominently in the grey bar at the top of a person's page. However, there is also a (more cryptic) unique identifier associated with a dblp person record. You can find this key listed in the "export" drop down menu right next to the name. The key can also be found as the "key" attribute of the "person" element in a persons XML export.</obo:IAO_0000115>
+        <obo:IAO_0000118 xml:lang="en">dblp ID</obo:IAO_0000118>
+        <obo:IAO_0000119 rdf:resource="https://dblp.org/faq/5210253.html"/>           
+    </owl:DatatypeProperty>
+
+
     </owl:DatatypeProperty>
 
     <!-- http://vivoweb.org/ontology/core#seatingCapacity -->

--- a/vivo.owl
+++ b/vivo.owl
@@ -4790,7 +4790,6 @@ Definition source: https://ror.org/about/</obo:IAO_0000112>
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Organization"/>
     </owl:DatatypeProperty>
 
-
     <!-- http://vivoweb.org/ontology/core#scopusId -->
 
     <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#scopusId">
@@ -4800,7 +4799,14 @@ Definition source: https://ror.org/about/</obo:IAO_0000112>
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
     </owl:DatatypeProperty>
 
+    <!-- http://vivoweb.org/ontology/core#dblpId -->
 
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#dblpId">
+        <rdfs:label xml:lang="en">dblp ID</rdfs:label>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The dblp computer science bibliography provides open bibliographic information on major computer science journals and proceedings. Definition source: https://dblp.org/. The DBLP ID uniquely identifies researchers in the DBLP.</obo:IAO_0000112>
+        <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
+        <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    </owl:DatatypeProperty>
 
     <!-- http://vivoweb.org/ontology/core#seatingCapacity -->
 

--- a/vivo.owl
+++ b/vivo.owl
@@ -4485,6 +4485,23 @@ modern society using the world of Star trek. Los Angeles Times, March
 
 
 
+    <!-- http://vivoweb.org/ontology/core#dblpPersonKey -->
+        <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#dblpPersonKey">        
+        <rdfs:label xml:lang="en">dblp Person Key</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
+        <rdfs:isDefinedBy rdf:resource="http://vivoweb.org/ontology/core"/>  
+        <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>    
+        <obo:IAO_0000111 xml:lang="en">dblp Person Key</obo:IAO_0000111>
+        <rdfs:comment xml:lang="en">A dblp person key is a code used to uniquely identify a scientist by the "dblp computer science bibliography", a joint service of Schloss Dagstuhl - Leibniz Center for Informatics and the University of Trier. The dblp person key, combined with the URI prefix, yields the resolvable URI of the entry. The key itself is an alphanumeric string composed of digits, letters, a slash and optionally a hyphen - e.g. [05/4792](https://dblp.org/pid/05/4792.html) or [z/KonradZuse](https://dblp.org/pid/z/KonradZuse.html)</rdfs:comment>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A dblp Person Key identifies a unique person in dblp such as https://dblp.org/pid/53/6062.html for Michael Conlon.</obo:IAO_0000112>
+        <vitro:exampleAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A dblp Person Key identifies a unique person in dblp such as https://dblp.org/pid/53/6062.html for Michael Conlon.</vitro:exampleAnnot>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">In many ways, persons are identified in dblp on basis of the persons name string (optionally followed by a four digit number in case of several authors in dblp with the same name). That name can be found prominently in the grey bar at the top of a person's page. However, there is also a (more cryptic) unique identifier associated with a dblp person record. You can find this key listed in the "export" drop down menu right next to the name. The key can also be found as the "key" attribute of the "person" element in a persons XML export.</obo:IAO_0000115>
+        <obo:IAO_0000118 xml:lang="en">dblp ID</obo:IAO_0000118>
+        <obo:IAO_0000119 rdf:resource="https://dblp.org/faq/5210253.html"/>
+    </owl:DatatypeProperty>
+
+
+
     <!-- http://vivoweb.org/ontology/core#departmentOrSchool -->
 
     <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#departmentOrSchool">


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: https://github.com/vivo-ontologies/vivo-ontology/issues/75

* Other relevant links (mailing list discussion, related pull requests, etc.)

# What does this pull request do?

Adds a new `rdfs:subPropertyOf http://vivoweb.org/ontology/core#identifier"` for person's IDs from https://dblp.uni-trier.de, an important bibliography for computer sciences with open bibliographic metadata.

# What's new?
Adds the property.

# Additional notes:
* Requires documentation to be updated

# Interested parties
@vivo-ontologies/team-members 