### PR TITLE
Add Mastodon ID

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -4655,6 +4655,18 @@ use one freetextKeyword assertion for each keyword or phrase.</obo:IAO_0000112>
 
 
 
+    <!-- http://vivoweb.org/ontology/core#mastodonId -->
+
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#mastodonId">
+        <rdfs:label xml:lang="en">Mastodon ID</rdfs:label>
+        <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+        <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000003"/>
+        <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
+        <vitro:descriptionAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The Mastodon ID should be entered in the following format: https://mastodonserver.social/@username. Please replace 'mastodonserver.social' with the specific Mastodon server being utilised.</vitro:descriptionAnnot>
+    </owl:DatatypeProperty>
+
+
+
     <!-- http://vivoweb.org/ontology/core#middleName -->
 
     <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#middleName">


### PR DESCRIPTION
**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: https://github.com/vivo-ontologies/vivo-ontology/issues/75

* https://blog.tib.eu/2022/11/23/verification-of-scholarly-social-media-accounts-in-the-fediverse/

# What does this pull request do?
Adds Mastodon ID. Domains are foaf:agent and bfo:0000003 (Occurent) to include persons, organisations on the one hand, and events, projects etc. on the other hand.

# What's new?
Adds the possibility to create Mastodon IDs. IDs should be URLs. Vitro Annot property provides guidance on how to enter the ID.

# Additional notes:
* Does this change require documentation to be updated? 
Yes, this would be a nice feature that should be mentioned.

* Does this change add any new dependencies or ontology imports? 
No.

* Could this change affect the VIVO application or data described with the ontology?
To allow usage of the verification feature, the following should be added to the display in the VIVO application:
<a rel="me" href="https://mastodonserver.social/@username">https://mastodonserver.social/@username</a>

# Interested parties
@vivo-ontologies/team-members 
