### PR TITLE
Deprecate vivo:F1000Link with annotations per issue #33

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -9632,10 +9632,11 @@ This class allows for linking an author to a publication while indicating inform
 
     <!-- http://vivoweb.org/ontology/core#F1000Link -->
 
-    <owl:Class rdf:about="http://vivoweb.org/ontology/core#F1000Link">
-        <rdfs:label xml:lang="en">F1000 Link</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/2006/vcard/ns#URL"/>
-        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">F1000 is a place where faculty go to critique papers published in PubMed. Any given record in F1000 might have anywhere from one to dozens of reviews.</obo:IAO_0000112>
+     <owl:Class rdf:about="http://vivoweb.org/ontology/core#F1000Link">
+        <vitro:descriptionAnnot>This resource is deprecated. See https://github.com/vivo-ontologies/vivo-ontology/issues/33 for details.</vitro:descriptionAnnot>
+        <rdfs:comment>DEPRECATED The class &quot;F1000 Link&quot; (vivo:F1000Link) currently holds a special position in the VIVO ontology as it is the only subclass of vcard:URL. F1000 does not have this relevance and this is also not consistent with the rest of the ontology.</rdfs:comment>
+        <rdfs:label xml:lang="en">DEPRECATED F1000 Link</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
 
 


### PR DESCRIPTION

**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues/33)

# What does this pull request do?
This PR deprecates the class `vivo:F1000Link` as discussed in issue #33.

# What's new?

- vitro:descriptionAnnot added with link to github issue
- owl:deprecated set to `true`
- rdfs:comment explaining reason for deprecation
- rdfs:label changed to DEPRECATED F1000 Link
- obo:IAO_0000112 description removed
- rdfs:subClassOf removed

# Additional notes:

vivo:F1000Link has no children

I'm not sure how to answer all questions right now, happy to update based on feedback!

Example:
* Does this change require documentation to be updated? 
* Does this change add any new dependencies or ontology imports? 
* Does this change require any other changes to be made to the repository? 
* Could this change affect the VIVO application or data described with the ontology?

# Interested parties
@hauschke 
