### PR TITLE
Add Dimensions Researcher ID property

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -4503,6 +4503,19 @@ modern society using the world of Star trek. Los Angeles Times, March
 
 
 
+    <!-- http://example.org/ontology/core#dimensionsResearcherId -->
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/core#dimensionsResearcherId">
+       <rdfs:label xml:lang="en">Dimensions Researcher ID</rdfs:label>
+       <rdfs:comment xml:lang="en">The Dimensions Researcher ID is the identifier that Digital Science Dimensions is using to differentiate researchers.</rdfs:comment>
+       <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ur.010172570453.47</obo:IAO_0000112>
+       <vitro:exampleAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ur.010172570453.47</vitro:exampleAnnot>
+       <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
+       <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+    </owl:DatatypeProperty>
+
+
+
     <!-- http://vivoweb.org/ontology/core#eRACommonsId -->
 
     <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#eRACommonsId">

--- a/vivo.owl
+++ b/vivo.owl
@@ -4505,7 +4505,7 @@ modern society using the world of Star trek. Los Angeles Times, March
 
     <!-- http://example.org/ontology/core#dimensionsResearcherId -->
 
-    <owl:DatatypeProperty rdf:about="http://example.org/ontology/core#dimensionsResearcherId">
+    <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#dimensionsResearcherId">
        <rdfs:label xml:lang="en">Dimensions Researcher ID</rdfs:label>
        <rdfs:comment xml:lang="en">The Dimensions Researcher ID is the identifier that Digital Science Dimensions is using to differentiate researchers.</rdfs:comment>
        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ur.010172570453.47</obo:IAO_0000112>


### PR DESCRIPTION
Added a new datatype property for vivo:dimensionsResearcherId with relevant annotations and comments.

**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: https://github.com/vivo-ontologies/vivo-ontology/issues/75

# What does this pull request do?
Adds the ID being used for persons in Dimensions. There seems to be no official definition of this identifier. The closest I could find: https://dimensions.freshdesk.com/support/solutions/articles/23000018779-how-are-researchers-unified-disambiguated-in-dimensions-

# What's new?
A new subproperty of vivo:identifier with the most essential annotations.

# Additional notes:
* Does this change require documentation to be updated? 
Only needs to be added in a list of available IDs.

* Does this change add any new dependencies or ontology imports? 
No.

* Does this change require any other changes to be made to the repository? 
No.

* Could this change affect the VIVO application or data described with the ontology?
Display needs to be added. 

# Interested parties
@vivo-ontologies/team-members 
