### PR TITLE
Add ISNI ID property

### DIFF
--- a/vivo.owl
+++ b/vivo.owl
@@ -4897,6 +4897,21 @@ See also core:localAwardId.
 
 
 
+    <!-- http://example.org/ontology/core#internationalStandardNameIdentifier -->
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/core#internationalStandardNameIdentifier">
+        <rdfs:label xml:lang="en">International Standard Name Identifier</rdfs:label>
+        <obo:IAO_0000111 xml:lang="en">ISNI</obo:IAO_0000111>
+        <rdfs:comment xml:lang="en">The International Standard Name Identifier (ISNI) is a unique identifier for actors in intellectual or artistic ontents.</rdfs:comment>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">115441915</obo:IAO_0000112>
+        <vitro:exampleAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">115441915</vitro:exampleAnnot>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISNI is a standard that uniquely identifies Public Identities involved throughout the chain of creation, production, management and distribution of intellectual or artistic contents. It identifies the Public Identities of Parties such as authors, composers, cartographers, performers, academic and scientific authors, researchers.  ISNI also identifies Public Identities of organisations or groups involved in these roles. These include musical groups and other performing acts, as well as business firms, publishers, universities and their departments, and any other group of people acting together under a common name.</obo:IAO_0000115>
+        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://isni.org/page/faqs/</obo:IAO_0000119>
+        <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
+    </owl:DatatypeProperty>
+
+
+
     <!-- http://vivoweb.org/ontology/scientific-research#irbNumber -->
 
     <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/scientific-research#irbNumber">

--- a/vivo.owl
+++ b/vivo.owl
@@ -4576,6 +4576,22 @@ use one freetextKeyword assertion for each keyword or phrase.</obo:IAO_0000112>
 
 
 
+    <!-- http://example.org/ontology/core#internationalStandardNameIdentifier -->
+
+    <owl:DatatypeProperty rdf:about="http://example.org/ontology/core#internationalStandardNameIdentifier">
+        <rdfs:label xml:lang="en">International Standard Name Identifier</rdfs:label>
+        <obo:IAO_0000111 xml:lang="en">ISNI</obo:IAO_0000111>
+        <rdfs:comment xml:lang="en">The International Standard Name Identifier (ISNI) is a unique identifier for actors in intellectual or artistic ontents.</rdfs:comment>
+        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">115441915</obo:IAO_0000112>
+        <vitro:exampleAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">115441915</vitro:exampleAnnot>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISNI is a standard that uniquely identifies Public Identities involved throughout the chain of creation, production, management and distribution of intellectual or artistic contents. It identifies the Public Identities of Parties such as authors, composers, cartographers, performers, academic and scientific authors, researchers.  ISNI also identifies Public Identities of organisations or groups involved in these roles. These include musical groups and other performing acts, as well as business firms, publishers, universities and their departments, and any other group of people acting together under a common name.</obo:IAO_0000115>
+        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://isni.org/page/faqs/</obo:IAO_0000119>
+        <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
+        <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
+    </owl:DatatypeProperty>
+
+
+
     <!-- http://vivoweb.org/ontology/core#hrJobTitle -->
 
     <owl:DatatypeProperty rdf:about="http://vivoweb.org/ontology/core#hrJobTitle">
@@ -4893,21 +4909,6 @@ See also core:localAwardId.
                 </owl:unionOf>
             </owl:Class>
         </rdfs:domain>
-    </owl:DatatypeProperty>
-
-
-
-    <!-- http://example.org/ontology/core#internationalStandardNameIdentifier -->
-
-    <owl:DatatypeProperty rdf:about="http://example.org/ontology/core#internationalStandardNameIdentifier">
-        <rdfs:label xml:lang="en">International Standard Name Identifier</rdfs:label>
-        <obo:IAO_0000111 xml:lang="en">ISNI</obo:IAO_0000111>
-        <rdfs:comment xml:lang="en">The International Standard Name Identifier (ISNI) is a unique identifier for actors in intellectual or artistic ontents.</rdfs:comment>
-        <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">115441915</obo:IAO_0000112>
-        <vitro:exampleAnnot rdf:datatype="http://www.w3.org/2001/XMLSchema#string">115441915</vitro:exampleAnnot>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISNI is a standard that uniquely identifies Public Identities involved throughout the chain of creation, production, management and distribution of intellectual or artistic contents. It identifies the Public Identities of Parties such as authors, composers, cartographers, performers, academic and scientific authors, researchers.  ISNI also identifies Public Identities of organisations or groups involved in these roles. These include musical groups and other performing acts, as well as business firms, publishers, universities and their departments, and any other group of people acting together under a common name.</obo:IAO_0000115>
-        <obo:IAO_0000119 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://isni.org/page/faqs/</obo:IAO_0000119>
-        <rdfs:subPropertyOf rdf:resource="http://vivoweb.org/ontology/core#identifier"/>
     </owl:DatatypeProperty>
 
 


### PR DESCRIPTION
Added a new datatype property for vivo:internationalStandardNameIdentifier with relevant annotations and comments.

**[VIVO-Ontology GitHub issue](https://github.com/vivo-ontologies/vivo-ontology/issues)**: https://github.com/vivo-ontologies/vivo-ontology/issues/75

# What does this pull request do?
Adds ISNI as a subproperty of vivo:identifier, including the mandatory and some more annotations.

# Additional notes:
* Does this change require documentation to be updated? 
Only needs to be added in a list of available IDs.

* Does this change add any new dependencies or ontology imports? 
No.

* Does this change require any other changes to be made to the repository? 
No.

* Could this change affect the VIVO application or data described with the ontology?
Display needs to be added. 

# Interested parties
@vivo-ontologies/team-members 
